### PR TITLE
Update precursor handling and refactor fission production

### DIFF
--- a/LBKEigenvalueSolver/IterativeMethods/lbkes_power_iteration.cc
+++ b/LBKEigenvalueSolver/IterativeMethods/lbkes_power_iteration.cc
@@ -122,7 +122,8 @@ void KEigenvalueSolver::PowerIteration()
   }//for k iterations
 
   //================================================== Initialize the precursors
-  ComputePrecursors();
+  if (options.use_precursors)
+    ComputePrecursors();
 
   //================================================== Print summary
   chi_log.Log(LOG_0) << "\n";

--- a/LBKEigenvalueSolver/IterativeOperations/lbkes_computeproduction.cc
+++ b/LBKEigenvalueSolver/IterativeOperations/lbkes_computeproduction.cc
@@ -47,20 +47,11 @@ double KEigenvalueSolver::ComputeFissionProduction()
       size_t ir = full_cell_view.MapDOF(i, 0, 0);
       double IntV_ShapeI = fe_intgrl_values.IntV_shapeI(i);
 
-      // only fissile materials contribute
-      if (xs->is_fissile)
-      {
-        for (size_t g = first_grp; g <= last_grp; ++g)
-        {
-          //TODO: Once checks are in place to ensure nu = nu_prompt +
-          //      nu_delayed, nu_sigma_f can be universally used here.
-          double nu_sigma_f =
-              (not options.use_precursors) ? xs->nu_sigma_f[g] :
-              xs->nu_prompt_sigma_f[g] + xs->nu_delayed_sigma_f[g];
-
-          local_production += nu_sigma_f * phi_new_local[ir + g] * IntV_ShapeI;
-        }// for group
-      }
+      //=================================== Loop over groups
+      for (size_t g = first_grp; g <= last_grp; ++g)
+        local_production += xs->nu_sigma_f[g] *
+                            phi_new_local[ir + g] *
+                            IntV_ShapeI;
     }//for node
   }//for cell
 

--- a/LBKEigenvalueSolver/lbkes_computeprecursors.cc
+++ b/LBKEigenvalueSolver/lbkes_computeprecursors.cc
@@ -9,53 +9,51 @@ using namespace LinearBoltzmann;
 /**Computes the point wise delayed neutron precursor concentrations.*/
 void KEigenvalueSolver::ComputePrecursors()
 {
-  if (options.use_precursors)
+
+  precursor_new_local.assign(precursor_new_local.size(), 0.0);
+
+  //================================================== Loop over cells
+  for (auto& cell : grid->local_cells)
   {
-    precursor_new_local.assign(precursor_new_local.size(), 0.0);
+    auto& full_cell_view = cell_transport_views[cell.local_id];
 
-    //================================================== Loop over cells
-    for (auto& cell : grid->local_cells)
+    //==================== Obtain xs
+    int cell_matid = cell.material_id;
+    int xs_id = matid_to_xs_map[cell_matid];
+
+    if ((xs_id < 0) || (xs_id >= material_xs.size()))
     {
-      auto& full_cell_view = cell_transport_views[cell.local_id];
+      chi_log.Log(LOG_ALLERROR)
+          << "Cross-section lookup error\n";
+      exit(EXIT_FAILURE);
+    }
 
-      //==================== Obtain xs
-      int cell_matid = cell.material_id;
-      int xs_id = matid_to_xs_map[cell_matid];
+    auto xs = material_xs[xs_id];
 
-      if ((xs_id < 0) || (xs_id >= material_xs.size()))
+    //======================================== Loop over nodes
+    const int num_nodes = full_cell_view.NumNodes();
+    for (int i = 0; i < num_nodes; ++i)
+    {
+      size_t ir = full_cell_view.MapDOF(i, 0, 0);
+      size_t jr = discretization->MapDOFLocal(cell, i, precursor_uk_man, 0, 0);
+
+      // contribute if precursors live on this material
+      if (xs->num_precursors > 0)
       {
-        chi_log.Log(LOG_ALLERROR)
-            << "Cross-section lookup error\n";
-        exit(EXIT_FAILURE);
-      }
-
-      auto xs = material_xs[xs_id];
-
-      //======================================== Loop over nodes
-      const int num_nodes = full_cell_view.NumNodes();
-      for (int i = 0; i < num_nodes; ++i)
-      {
-        size_t ir = full_cell_view.MapDOF(i, 0, 0);
-        size_t jr = discretization->MapDOFLocal(cell, i, precursor_uk_man, 0, 0);
-
-        // contribute if precursors live on this material
-        if (xs->num_precursors > 0)
+        //======================================== Loop over precursors
+        for (size_t j = 0; j < xs->num_precursors; ++j)
         {
-          //======================================== Loop over precursors
-          for (size_t j = 0; j < xs->num_precursors; ++j)
+          //======================================== Loop over groups
+          for (size_t g = 0; g < groups.size(); ++g)
           {
-            //======================================== Loop over groups
-            for (size_t g = 0; g < groups.size(); ++g)
-            {
-              precursor_new_local[jr + j] +=
-                  xs->precursor_yield[j] / xs->precursor_lambda[j] *
-                  xs->nu_delayed_sigma_f[g] * phi_new_local[ir + g] / k_eff;
-            }//for group
-          }//for precursors
-        }//if num_precursors > 0
-      } //for node
-    }//for cell
-  }
+            precursor_new_local[jr + j] +=
+                xs->precursor_yield[j] / xs->precursor_lambda[j] *
+                xs->nu_delayed_sigma_f[g] * phi_new_local[ir + g] / k_eff;
+          }//for group
+        }//for precursors
+      }//if num_precursors > 0
+    } //for node
+  }//for cell
 }
 
 


### PR DESCRIPTION
## Notes

- Check `options.use_precursors` before computing precursor concentrations instead of checking within the routine.
- Use `nu_sigma_f` within `ComputeFissionProduction` now the `nu = nu_prompt + nu_delayed` is enforced.