### PR TITLE
Made compatible with ChiTech base update.

### DIFF
--- a/LBKEigenvalueSolver/lbkes_k_eigenvalue_solver.h
+++ b/LBKEigenvalueSolver/lbkes_k_eigenvalue_solver.h
@@ -29,6 +29,8 @@ public:
   std::vector<double> precursor_new_local;
 
 public:
+  explicit KEigenvalueSolver(const std::string& in_text_name) :
+    LinearBoltzmann::Solver(in_text_name) {}
 
   void Initialize() override;
   void Execute() override;

--- a/LBKEigenvalueSolver/lua/lbkes_createsolver.cc
+++ b/LBKEigenvalueSolver/lua/lbkes_createsolver.cc
@@ -14,12 +14,23 @@ using namespace LinearBoltzmann;
 /**Create the solver.*/
 int chiLBKESCreateSolver(lua_State* L)
 {
-  chi_log.Log(LOG_ALLVERBOSE_1)
-      << "Creating k-eigenvalue solver.";
-  auto solver = new KEigenvalueSolver;
+  const std::string fname = __FUNCTION__;
+  int num_args = lua_gettop(L);
+
+  chi_log.Log(LOG_ALLVERBOSE_1) << "Creating k-eigenvalue solver.";
+
+  std::string solver_name = "KEigenvalueSolver";
+  if (num_args == 1)
+  {
+    LuaCheckStringValue(fname, L, 1);
+    solver_name = lua_tostring(L, 1);
+  }
+
+  auto solver = new KEigenvalueSolver(solver_name);
 
   chi_physics_handler.solver_stack.push_back(solver);
 
-  lua_pushnumber(L, chi_physics_handler.solver_stack.size() - 1);
+  auto n = static_cast<lua_Integer>(chi_physics_handler.solver_stack.size() - 1);
+  lua_pushinteger(L, n);
   return 1;
 }


### PR DESCRIPTION
This PR bring `LinearBoltzman::KEigenvalueSolver` up to date with the main ChiTech repository.